### PR TITLE
Using TCK Tested JDK builds of OpenJDK

### DIFF
--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -22,7 +22,7 @@ jobs:
       max-parallel: 9 # Sum of matrices.
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        java: [8, 11, 15]
+        java: [8, 8.0.192, 11, 11.0.3, 15]
         
     runs-on: ${{ matrix.os }}
     
@@ -36,7 +36,7 @@ jobs:
       uses: actions/setup-java@v2
       with:
         java-version: ${{ matrix.java }}
-        distribution: 'adopt'
+        distribution: 'zulu'
         
     - name: Install Google Chrome before maven test on linux
       if: runner.os == 'Linux'


### PR DESCRIPTION
The AdoptOpenJDK has been discontinued since July 2021. When using Zulu you get all the latest updated (TCK Tested) builds for all versions of OpenJDK. Also added fixed releases as good practice. Some customers or companies are stuck on major releases and if you build on the latest it could break or fail.